### PR TITLE
added a util for creating more robust parsers

### DIFF
--- a/app/api/chats/[id]/route.ts
+++ b/app/api/chats/[id]/route.ts
@@ -31,7 +31,7 @@ export async function GET(_req: NextRequest, { params }: IdParamProps) {
 export async function PATCH(req: NextRequest, { params }: IdParamProps) {
   try {
     const rawPayload: unknown = await req.json();
-    const chatUpdates: PatchChat = PatchChat.schema.parse(rawPayload);
+    const chatUpdates = PatchChat.parse(rawPayload);
     const id = await IdParamProps.parseNumberId(params);
     console.info(`Updating chat ${id} with argument ${chatUpdates}`);
 

--- a/app/chat/chat-network-requests.ts
+++ b/app/chat/chat-network-requests.ts
@@ -6,7 +6,7 @@ export const getChat = async (): Promise<Chat> => {
   });
 
   const text: unknown = await response.json();
-  return Chat.schema.parse(text);
+  return Chat.parse(text);
 };
 
 export const postChat = async (body: unknown) => {

--- a/models/chat-model.ts
+++ b/models/chat-model.ts
@@ -1,4 +1,5 @@
-import { z, ZodType } from 'zod';
+import { z } from 'zod';
+import { SchemaReturnType } from '../utils/zod';
 
 export type Chat = Readonly<{
   context: ReadonlyArray<string>;
@@ -10,7 +11,10 @@ export const Chat = {
     context: z.array(z.string()),
     message: z.string(),
   }),
-} as const satisfies { schema: ZodType<Chat> };
+  parse(x: unknown): Chat {
+    return Chat.schema.parse(x);
+  },
+} as const satisfies SchemaReturnType<Chat>;
 
 export type PatchChat = Readonly<{
   message: string;
@@ -20,4 +24,5 @@ export const PatchChat = {
   schema: z.object({
     message: z.string(),
   }),
-} as const satisfies { schema: ZodType<PatchChat> };
+  parse: (x: unknown): PatchChat => PatchChat.schema.parse(x),
+} as const satisfies SchemaReturnType<PatchChat>;

--- a/utils/zod.ts
+++ b/utils/zod.ts
@@ -1,0 +1,48 @@
+import { ZodError, ZodType } from 'zod';
+
+/**
+ * ## Helper Utility to guarantee correct parsing
+ * ---
+ *
+ * This helper works in conjunction with the `satisfies`
+ * utility in typescript.
+ *
+ * It guarantees that an object
+ * has a property called `schema` that is a zod parser that
+ * returns the type you give it.
+ *
+ * It also requires that there is a `parse` methods,
+ * which should be a function run the aforementioned
+ * schema.
+ *
+ * ---
+ *
+ * @example
+ * for context lets say you have this type:
+ * ```typescript
+ * type User = {
+ *   name: string,
+ *   age: number,
+ * }
+ * ```
+ * if we are to make a parser for that, we can write it like this:
+ * ```typescript
+ * const User = {
+ *   schema: z.object({
+ *     name: z.string(), // this property must be there and must be a string
+ *     age: z.number(), // this is also enforced
+ *   }),
+ *   parse: (x: unknown) => User.schema.parse(x)
+ * // This satisfies statement is what enforces that the parse and schema fields are there.
+ * } as const satisfies SchemaReturnType<User>; // just pass in the type you want this parser to guarantee
+ */
+export type SchemaReturnType<T> = {
+  /** The zod schmea for type passed into this utility */
+  schema: ZodType<T>;
+  /**
+   * A method that can take in one argument,
+   * which can be anything at all, and it returns
+   * a result of type  passed into this utility or throws a {@link ZodError} exception
+   * */
+  parse: (x: unknown) => T;
+} & Record<string, unknown>;


### PR DESCRIPTION
## What does this pr do?

This adds a type utility called `SchemaReturnType`, which takes in a generic and returns an object interface that has at least two properties — `schema` and `parse`,

 - `schema` is the zod parser itself
 - `parse` is a shorthand method that guarantees a return type of whatever the schema is meant ot be parsing.

## Why is this useful?

The `SchemaReturnType` utility guarantees that you don't accidentally have a mis-match in your parser and your declared type.

Adding the `parse` method allows for cleaner and easier parsing of data, since it is using a named type rather than relying on zod's inferencing.